### PR TITLE
feat:re-enable apt:recommends

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -33,7 +33,7 @@ lb config noauto \
     \
     --keyring-packages debian-keyring \
     --apt-options "--yes --option Acquire::Retries=5 --option Acquire::http::Timeout=100" \
-    --apt-recommends false \
+    --apt-recommends true \
     --cache-packages false \
     --uefi-secure-boot enable \
     --binary-images iso \


### PR DESCRIPTION
because packages ha critical deps marked as recommends for somewhat reason